### PR TITLE
move expand icon to the right

### DIFF
--- a/src/views/Minimized.tsx
+++ b/src/views/Minimized.tsx
@@ -10,14 +10,11 @@ const MinimizedView: FunctionComponent = () => (
   <>
     <Header
       title={
-        <div
-          style={{
-            color: state.settings.color || '#000'
-          }}
-        >
+        <Title color={state.settings.color || '#000'}>
           {state.settings.name}
-        </div>
+        </Title>
       }
+      left={<span></span>}
       right={
         <SharedIcon onClick={state.toggleMinimizeChat}>
           <div className="icon icon--plus" />
@@ -52,6 +49,11 @@ const Minimized = styled.div`
   button {
     cursor: pointer;
   }
+`;
+
+const Title = styled.div`
+  margin-left: 10px;
+  color: ${props => props.color};
 `;
 
 const Users = styled.div`

--- a/src/views/Minimized.tsx
+++ b/src/views/Minimized.tsx
@@ -18,7 +18,7 @@ const MinimizedView: FunctionComponent = () => (
           {state.settings.name}
         </div>
       }
-      left={
+      right={
         <SharedIcon onClick={state.toggleMinimizeChat}>
           <div className="icon icon--plus" />
         </SharedIcon>


### PR DESCRIPTION
this is just a suggestion, as I keep pressing the settings icon by accident when switching back to expanded.
I haven't tested, but looking at the header component, it looks like it only needs this simple change.

hats off, for the way you have the components structured, really easy to read for a non developer 🙏